### PR TITLE
Update project references from adcaudill to Numorian

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2019 Adam Caudill
+Copyright (c) 2019-2025 Adam Caudill
+Copyright (c) 2025 Numorian, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A JSON file containing the current version of various server software packages. 
 
 ## Getting the file
 
-For now, the easiest way to access the file is via: https://raw.githubusercontent.com/adcaudill/current_versions/main/current_versions.json
+For now, the easiest way to access the file is via: https://raw.githubusercontent.com/Numorian/current_versions/main/current_versions.json
 
 ## Updates
 
@@ -11,4 +11,4 @@ If you find a package listed with an outdated version number, please open a PR t
 
 ## License
 
-This data is licensed under the MIT license, and is thus available under very liberal terms. See the [LICENSE](https://github.com/adcaudill/current_versions/blob/main/LICENSE) file for details.
+This data is licensed under the MIT license, and is thus available under very liberal terms. See the [LICENSE](https://github.com/Numorian/current_versions/blob/main/LICENSE) file for details.

--- a/current_versions.json
+++ b/current_versions.json
@@ -1,7 +1,7 @@
 {
-	"_copyright": "Copyright 2025 Adam Caudill <adam@adamcaudill.com>",
+	"_copyright": "Copyright 2025 Numorian <contact@numorian.com>",
 	"_license": "MIT",
-	"_info": "https://github.com/adcaudill/current_versions",
+	"_info": "https://github.com/Numorian/current_versions",
 	"software": {
 		"apache_httpd": {
 			"latest": "2.4.63",


### PR DESCRIPTION
Changed all references in README.md and current_versions.json from 'adcaudill' to 'Numorian', including URLs, copyright, and contact information.